### PR TITLE
Add renovate with widen strategy for grpc packages.

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,24 @@
+name: Renovate dependency updater
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  renovate:
+    runs-on: [self-hosted, static]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v46.1.6
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          RENOVATE_AUTODISCOVER: "true"
+          RENOVATE_AUTODISCOVER_FILTER: "shakenfist/client-python-k3s"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "gitAuthor": "shakenfist-bot <bot@shakenfist.com>",
+  "dependencyDashboard": true,
+  "assignees": [
+    "mikalstill"
+  ],
+  "schedule": [
+    "after 9pm"
+  ],
+  "packageRules": [
+    {
+      "description": "Group grpc packages together with widen strategy",
+      "matchPackagePatterns": [
+        "^grpcio",
+        "^googleapis-common-protos",
+        "^protobuf"
+      ],
+      "groupName": "grpc packages",
+      "rangeStrategy": "widen"
+    },
+    {
+      "description": "Automatically merge minor and patch-level updates",
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest"
+      ],
+      "automerge": false
+    }
+  ],
+  "minimumReleaseAge": "3 days",
+  "rollbackPrs": true
+}


### PR DESCRIPTION
Add renovate.json and CI workflow. Use rangeStrategy "widen" for grpc packages so renovate only creates PRs for new major versions, avoiding unnecessary churn when dependencies use >= constraints.

Prompt: For each of shakenfist/agent-python, client-python, client-python-k3s, clingwrap, and occystrap: update renovate.json to use widen rangeStrategy for grpc packages.